### PR TITLE
Make deployment of other branches than 'master' work for Git versions ≥ 1.6.6

### DIFF
--- a/lib/heroku_deployer.rb
+++ b/lib/heroku_deployer.rb
@@ -45,7 +45,7 @@ class HerokuDeployer
   end
 
   def local_folder
-    @local_folder ||= "repos/#{Zlib.crc32(config.git_repo)}"
+    @local_folder ||= "repos/#{Zlib.crc32(config.git_repo + config.github_branch)}"
   end
 
   def repo_exists?
@@ -57,14 +57,17 @@ class HerokuDeployer
       wrapper.set_env
       clone unless repo_exists?
       logger.info "fetching #{config.github_branch}"
-      logger.debug `cd #{local_folder} && git fetch && git checkout #{config.github_branch} && git pull`
+      logger.debug `cd #{local_folder} && git fetch && git reset --hard origin/#{config.github_branch}`
     end
   end
 
   def clone
     logger.info "cloning"
     logger.debug `git clone #{config.git_repo} #{local_folder}`
+    logger.info "switching to branch #{config.github_branch}"
+    logger.debug `cd #{local_folder} && git fetch && git checkout #{config.github_branch} && git pull`
     logger.debug `cd #{local_folder} && git remote add heroku #{config.heroku_repo}`
+
   end
 
   def push

--- a/lib/heroku_deployer.rb
+++ b/lib/heroku_deployer.rb
@@ -57,17 +57,13 @@ class HerokuDeployer
       wrapper.set_env
       clone unless repo_exists?
       logger.info "fetching #{config.github_branch}"
-      #logger.debug `cd #{local_folder} && git fetch && git reset --hard origin/#{config.github_branch}`
-      logger.info "# cd #{local_folder} && git fetch && git checkout #{config.github_branch} && git pull"
       logger.debug `cd #{local_folder} && git fetch && git checkout #{config.github_branch} && git pull`
     end
   end
 
   def clone
     logger.info "cloning"
-    logger.info "# git clone #{config.git_repo} #{local_folder}"
     logger.debug `git clone #{config.git_repo} #{local_folder}`
-    logger.info "# cd #{local_folder} && git remote add heroku #{config.heroku_repo}"
     logger.debug `cd #{local_folder} && git remote add heroku #{config.heroku_repo}`
   end
 
@@ -75,7 +71,6 @@ class HerokuDeployer
     GitSSHWrapper.with_wrapper(:private_key => ENV['DEPLOY_SSH_KEY']) do |wrapper|
       wrapper.set_env
       logger.info "pushing"
-      logger.info "# cd #{local_folder}; git push -f heroku #{config.github_branch}:master"
       logger.debug `cd #{local_folder}; git push -f heroku #{config.github_branch}:master`
     end
   end

--- a/lib/heroku_deployer.rb
+++ b/lib/heroku_deployer.rb
@@ -57,13 +57,17 @@ class HerokuDeployer
       wrapper.set_env
       clone unless repo_exists?
       logger.info "fetching #{config.github_branch}"
-      logger.debug `cd #{local_folder} && git fetch && git reset --hard origin/#{config.github_branch}`
+      #logger.debug `cd #{local_folder} && git fetch && git reset --hard origin/#{config.github_branch}`
+      logger.info "# cd #{local_folder} && git fetch && git checkout #{config.github_branch} && git pull"
+      logger.debug `cd #{local_folder} && git fetch && git checkout #{config.github_branch} && git pull`
     end
   end
 
   def clone
     logger.info "cloning"
+    logger.info "# git clone #{config.git_repo} #{local_folder}"
     logger.debug `git clone #{config.git_repo} #{local_folder}`
+    logger.info "# cd #{local_folder} && git remote add heroku #{config.heroku_repo}"
     logger.debug `cd #{local_folder} && git remote add heroku #{config.heroku_repo}`
   end
 
@@ -71,6 +75,7 @@ class HerokuDeployer
     GitSSHWrapper.with_wrapper(:private_key => ENV['DEPLOY_SSH_KEY']) do |wrapper|
       wrapper.set_env
       logger.info "pushing"
+      logger.info "# cd #{local_folder}; git push -f heroku #{config.github_branch}:master"
       logger.debug `cd #{local_folder}; git push -f heroku #{config.github_branch}:master`
     end
   end

--- a/lib/web.rb
+++ b/lib/web.rb
@@ -19,6 +19,7 @@ class Web < Sinatra::Application
   end
 
   post '/deploy/:app_name/:secret' do |app_name, secret|
+    request.body.rewind  # in case someone already read it
     if ENV["#{app_name}_BRANCH"]
       payload = JSON.parse(request.body.read)
       branch = payload["ref"].split("/").last


### PR DESCRIPTION
just give it a try. if you had deployed manually to heroku before, the old approach failes:

  2014-11-26T00:49:49.215907+00:00 app[web.1]: Fetching repository, done.
  2014-11-26T00:49:54.441869+00:00 app[web.1]: error: src refspec develop does not match any.
  2014-11-26T00:49:54.442275+00:00 app[web.1]: error: failed to push some refs to 'git@heroku.com:****.git'

This fix works
